### PR TITLE
Bug fix for transaction events not getting written into buffer

### DIFF
--- a/blocking-bootstrap-producers/blocking-bootstrap-mysql-producer/pom.xml
+++ b/blocking-bootstrap-producers/blocking-bootstrap-mysql-producer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/consumers/client-event-consumer/pom.xml
+++ b/consumers/client-event-consumer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
   <artifactId>client-event-consumer</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-client-cluster</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
     </dependencies>
 </project>

--- a/data-layers/data-layer-console-appender/pom.xml
+++ b/data-layers/data-layer-console-appender/pom.xml
@@ -3,7 +3,7 @@
       <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
        </parent>
   <artifactId>data-layer-console-appender</artifactId>
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-client-cluster</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>client-event-consumer</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
   </dependencies>
 </project>

--- a/data-layers/data-layer-elastic-search/pom.xml
+++ b/data-layers/data-layer-elastic-search/pom.xml
@@ -3,7 +3,7 @@
       <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
   <groupId>com.flipkart.aesop</groupId>
@@ -57,12 +57,12 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-client-cluster</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>client-event-consumer</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
   </dependencies>
 </project>

--- a/data-layers/data-layer-hbase/pom.xml
+++ b/data-layers/data-layer-hbase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
   <artifactId>data-layer-hbase</artifactId>
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-client-cluster</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>client-event-consumer</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
   </dependencies>
 </project>

--- a/data-layers/data-layer-mysql/pom.xml
+++ b/data-layers/data-layer-mysql/pom.xml
@@ -3,7 +3,7 @@
       <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
   <artifactId>data-layer-mysql</artifactId>
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-client-cluster</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>client-event-consumer</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>aesop</artifactId>
     <name>Aesop Full Build</name>
     <packaging>pom</packaging>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/producers/diff-producer/pom.xml
+++ b/producers/diff-producer/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>diff-producer</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Serialized state diff event producer</name>
     <description>Serialized state diff event producer</description>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-relay</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
         <!-- Zeno dependencies -->
 		<dependency>

--- a/producers/hbase-producer/pom.xml
+++ b/producers/hbase-producer/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>hbase-producer</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Hbase WAL Edits event producer</name>
     <description>Hbase WAL Edits event producer</description>
 
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-relay</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
         <!-- HBase SEP dependencies -->
     	<dependency>

--- a/producers/mysql-producer/pom.xml
+++ b/producers/mysql-producer/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>mysql-producer</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Mysql event producer</name>
     <description>Mysql event producer</description>
 
@@ -120,12 +120,12 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-relay</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>   
         <dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>avro-schema-generator</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 			<exclusions>
 			  	<exclusion>
 			  		<groupId>org.mortbay.jetty</groupId>

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/txnprocessor/impl/MysqlTransactionManagerImpl.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/txnprocessor/impl/MysqlTransactionManagerImpl.java
@@ -213,7 +213,6 @@ public class MysqlTransactionManagerImpl implements MysqlTransactionManager
 				return;
 			}
 			perSourceTransaction = new PerSourceTransaction(srcId);
-			transaction.mergePerSourceTransaction(perSourceTransaction);
 		}
 		else
 		{
@@ -296,6 +295,12 @@ public class MysqlTransactionManagerImpl implements MysqlTransactionManager
 				{
 					perSourceTransaction.mergeDbChangeEntrySet(entry);
 				}
+                /**
+                 * This is added here, because, if the mergePersource TXN is called during setSource,
+                 * then , in the scenario where-in MysqlTransactionManagerImpl#perSourceTxn needs to be recycled,
+                 * the DBEntry obtained above are not yet added to the new Instance of perSourceTransaction
+                 */
+                transaction.mergePerSourceTransaction(perSourceTransaction);
 			}
 			else
 			{

--- a/runtimes/runtime-blocking-bootstrap/pom.xml
+++ b/runtimes/runtime-blocking-bootstrap/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>runtime-blocking-bootstrap</artifactId>
 	<name>Bootstrap Blocking Runtime</name>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<description>Blocking Bootstrap Runtime</description>
 
 	<properties>
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>runtime</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 		<!-- Databus dependencies -->
 		<dependency>

--- a/runtimes/runtime-bootstrap/pom.xml
+++ b/runtimes/runtime-bootstrap/pom.xml
@@ -6,13 +6,13 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>runtime-bootstrap</artifactId>
 	<name>Bootstrap Runtime</name>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<description>Bootstrap Runtime</description>
 
 	<properties>
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>runtime</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 		<!-- Databus dependencies -->
 		<dependency>

--- a/runtimes/runtime-client-bootstrap-producer/pom.xml
+++ b/runtimes/runtime-client-bootstrap-producer/pom.xml
@@ -6,14 +6,14 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<groupId>com.flipkart.aesop</groupId>
 	<artifactId>runtime-client-bootstrap-producer</artifactId>
 	<name>Client Bootstrap Producer Runtime</name>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<description>Client Bootstrap Producer Runtime</description>
 
 	<licenses>
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>runtime-client</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/runtimes/runtime-client-cluster/pom.xml
+++ b/runtimes/runtime-client-cluster/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>runtime-client-cluster</artifactId>
     <name>Client Cluster Runtime</name>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <description>Client Cluster Runtime</description>
 
     <licenses>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-client</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
     </dependencies>
 

--- a/runtimes/runtime-client/pom.xml
+++ b/runtimes/runtime-client/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
          <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>runtime-client</artifactId>
     <name>Client Runtime</name>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <description>Client Runtime</description>
 
     <licenses>
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    		    
     </dependencies>
 

--- a/runtimes/runtime-relay/pom.xml
+++ b/runtimes/runtime-relay/pom.xml
@@ -6,14 +6,14 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
          <relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<groupId>com.flipkart.aesop</groupId>
 	<artifactId>runtime-relay</artifactId>
 	<name>Relay Runtime</name>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<description>Relay Runtime</description>
 
 	<licenses>
@@ -146,7 +146,7 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>runtime</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/runtimes/runtime-snapshot-serializer/pom.xml
+++ b/runtimes/runtime-snapshot-serializer/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 <relativePath>../../pom.xml</relativePath>	
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>runtime-snapshot-serializer</artifactId>
     <name>Snapshot Serializer Runtime</name>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <description>Snapshot Serializer Runtime</description>
 
     <licenses>

--- a/runtimes/runtime/pom.xml
+++ b/runtimes/runtime/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>runtime</artifactId>
     <name>Runtime</name>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <description>Runtime</description>
 
     <properties>

--- a/samples/sample-bootstrap-server/pom.xml
+++ b/samples/sample-bootstrap-server/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>sample-bootstrap-server</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Sample Bootstrap Server</name>
     <description>Sample Bootstrap Server</description>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-bootstrap</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
     </dependencies>
 

--- a/samples/sample-client-bootstrap-producer/pom.xml
+++ b/samples/sample-client-bootstrap-producer/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>sample-client-bootstrap-producer</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Sample Client Bootstrap Producer</name>
     <description>Sample Client Bootstrap Producer</description>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-client-bootstrap-producer</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
     </dependencies>
 

--- a/samples/sample-client-cluster/pom.xml
+++ b/samples/sample-client-cluster/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/sample-client-common/pom.xml
+++ b/samples/sample-client-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/sample-client/pom.xml
+++ b/samples/sample-client/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>sample-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Sample Client</name>
     <description>Sample Client</description>
 
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-client</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
     </dependencies>
 

--- a/samples/sample-console-appender-client-cluster-consumer/pom.xml
+++ b/samples/sample-console-appender-client-cluster-consumer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>sample-console-appender-client-cluster-consumer</artifactId>
@@ -18,13 +18,13 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>runtime-client-cluster</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>data-layer-console-appender</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/samples/sample-diff-relay/pom.xml
+++ b/samples/sample-diff-relay/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
     	<relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>diff-producer</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
     </dependencies>
 

--- a/samples/sample-elastic-search-client-cluster-consumer/pom.xml
+++ b/samples/sample-elastic-search-client-cluster-consumer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.flipkart.aesop</groupId>
@@ -44,13 +44,13 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>runtime-client-cluster</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>data-layer-elastic-search</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 		
 	</dependencies>

--- a/samples/sample-hbase-client-cluster-consumer/pom.xml
+++ b/samples/sample-hbase-client-cluster-consumer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>sample-hbase-client-cluster-consumer</artifactId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>runtime-client-cluster</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>log4j-over-slf4j</artifactId>
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>data-layer-hbase</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>guava</artifactId>

--- a/samples/sample-hbase-relay/pom.xml
+++ b/samples/sample-hbase-relay/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>sample-hbase-relay</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Sample Relay with HBase WAL edits Producer</name>
     <description>Sample Relay with HBase WAL edits Producer</description>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>hbase-producer</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
             <exclusions>
             	<exclusion>
             		<artifactId>servlet-api-2.5</artifactId>

--- a/samples/sample-mapper-processor-nesting-client/pom.xml
+++ b/samples/sample-mapper-processor-nesting-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/sample-memory-relay/pom.xml
+++ b/samples/sample-memory-relay/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>sample-memory-relay</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Sample Relay with In-memory Producer</name>
     <description>Sample Relay with In-memory Producer</description>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-relay</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>    
     </dependencies>
 

--- a/samples/sample-mysql-mysql-blocking-bootstrap/pom.xml
+++ b/samples/sample-mysql-mysql-blocking-bootstrap/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>sample-mysql-mysql-blocking-bootstrap</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<name>Sample Blocking Bootstrap with MySQL Producer and Consumer</name>
 	<description>Sample Blocking Bootstrap with MySQL Producer and Consumer</description>
 

--- a/samples/sample-mysql-relay/pom.xml
+++ b/samples/sample-mysql-relay/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>	
 	</parent>
 	
 	<artifactId>sample-mysql-relay</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<name>Sample Relay with MySQL Producer</name>
 	<description>Sample Relay with MySql Producer</description>
 
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>com.flipkart.aesop</groupId>
 			<artifactId>mysql-producer</artifactId>
-			<version>1.1.0-SNAPSHOT</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 		<!-- Third party dependencies -->
 		<dependency>

--- a/samples/sample-snapshot-serializer/pom.xml
+++ b/samples/sample-snapshot-serializer/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.flipkart.aesop</groupId>
         <artifactId>aesop</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
 	<relativePath>../../pom.xml</relativePath>	
     </parent>
 
     <groupId>com.flipkart.aesop</groupId>
     <artifactId>sample-snapshot-serializer</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Sample Snapshot Serializer</name>
     <description>Sample Snapshot Serializer</description>
 
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.flipkart.aesop</groupId>
             <artifactId>runtime-snapshot-serializer</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
 		    <exclusions>
 	        	<exclusion> <!-- Remove slf4j over log4j -->
 		      	  <groupId>org.slf4j</groupId> 

--- a/utilities/avro-schema-generator/pom.xml
+++ b/utilities/avro-schema-generator/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>com.flipkart.aesop</groupId>
 		<artifactId>aesop</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.1.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>avro-schema-generator</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<name>avro-schema-generator</name>
 	<description>Generate avro schemas for mysql tables</description>
 	<url>http://maven.apache.org</url>


### PR DESCRIPTION
@jagadeesh-huliyar @Shoury 
Please review. There was a bug where-in in a single transaction if more than 2 rows were updated for the same table, entries were not getting written into eventBuffer.
This was true only in the following scenario
a) Even received for table 1 ( We are interested)
b) Event received for table 2 ( not interested)
c) Event received for table 1 ( We are interested)
in the same transaction.

Fix : 
I moved the  transaction.mergePerSourceTransaction(perSourceTransaction); from setSource Method to 
performChanges API. 
This will ensure that the new  DbChangeEntry received in (c) above gets merged into transactions#oldPerSourceTxn  