### PR TITLE
Adding the option to push events to diff doc types in ES

### DIFF
--- a/data-layers/data-layer-elastic-search/src/main/java/com/flipkart/aesop/processor/es/upsert/ElasticSearchPartialUpsertProcessor.java
+++ b/data-layers/data-layer-elastic-search/src/main/java/com/flipkart/aesop/processor/es/upsert/ElasticSearchPartialUpsertProcessor.java
@@ -10,6 +10,8 @@ import org.elasticsearch.action.update.UpdateResponse;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
+
 /**
  * <code>ElasticSearchPartialUpsertProcessor</code> is an elastic search upsert data layer which allows partial updates to an
  * existing document (based on simple recursive merge, inner merging of objects,
@@ -37,11 +39,13 @@ public class ElasticSearchPartialUpsertProcessor extends UpsertDestinationStoreP
         try {
 
             String docId = String.valueOf(event.getFieldMapPair().get("id"));
+            String index = isBlank(event.getNamespaceName()) ? elasticSearchClient.getIndex() : event.getNamespaceName();
+            String type = isBlank(event.getEntityName()) ? elasticSearchClient.getType() : event.getEntityName();
 
-            IndexRequest indexReq = new IndexRequest(elasticSearchClient.getIndex(), elasticSearchClient.getType(), docId).
+            IndexRequest indexReq = new IndexRequest(index, type, docId).
                     source(event.getFieldMapPair());
 
-            UpdateRequest updateReq = new UpdateRequest(elasticSearchClient.getIndex(), elasticSearchClient.getType(), docId).
+            UpdateRequest updateReq = new UpdateRequest(index, type, docId).
                     doc(event.getFieldMapPair()).
                     upsert(indexReq);
 

--- a/data-layers/data-layer-elastic-search/src/main/java/com/flipkart/aesop/processor/es/upsert/ElasticSearchPartialUpsertProcessor.java
+++ b/data-layers/data-layer-elastic-search/src/main/java/com/flipkart/aesop/processor/es/upsert/ElasticSearchPartialUpsertProcessor.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.update.UpdateResponse;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
 
 /**
  * <code>ElasticSearchPartialUpsertProcessor</code> is an elastic search upsert data layer which allows partial updates to an
@@ -39,13 +38,11 @@ public class ElasticSearchPartialUpsertProcessor extends UpsertDestinationStoreP
         try {
 
             String docId = String.valueOf(event.getFieldMapPair().get("id"));
-            String index = isBlank(event.getNamespaceName()) ? elasticSearchClient.getIndex() : event.getNamespaceName();
-            String type = isBlank(event.getEntityName()) ? elasticSearchClient.getType() : event.getEntityName();
 
-            IndexRequest indexReq = new IndexRequest(index, type, docId).
+            IndexRequest indexReq = new IndexRequest(event.getNamespaceName(), event.getEntityName(), docId).
                     source(event.getFieldMapPair());
 
-            UpdateRequest updateReq = new UpdateRequest(index, type, docId).
+            UpdateRequest updateReq = new UpdateRequest(event.getNamespaceName(), event.getEntityName(), docId).
                     doc(event.getFieldMapPair()).
                     upsert(indexReq);
 

--- a/data-layers/data-layer-elastic-search/src/main/java/com/flipkart/aesop/processor/es/upsert/ElasticSearchUpsertProcessor.java
+++ b/data-layers/data-layer-elastic-search/src/main/java/com/flipkart/aesop/processor/es/upsert/ElasticSearchUpsertProcessor.java
@@ -23,6 +23,8 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
+
 /**
  * ElasticSearch Upsert Data Layer. Persists {@link DbusOpcode#UPSERT} events to Logs.
  * @author Pratyay Banerjee
@@ -46,13 +48,16 @@ public class ElasticSearchUpsertProcessor extends UpsertDestinationStoreProcesso
         try {
             String id = String.valueOf(event.getFieldMapPair().get("id"));
             //delete if "id" exists
-            elasticSearchClient.getClient().prepareDelete(elasticSearchClient.getIndex(),
-                    elasticSearchClient.getType(), id)
+            String index = isBlank(event.getNamespaceName()) ? elasticSearchClient.getIndex() : event.getNamespaceName();
+            String type = isBlank(event.getEntityName()) ? elasticSearchClient.getType() : event.getEntityName();
+
+            elasticSearchClient.getClient().prepareDelete(index,
+                    type, id)
                     .execute()
                     .actionGet();
             //create the new id
-            IndexResponse response = elasticSearchClient.getClient().prepareIndex(elasticSearchClient.getIndex(),
-                    elasticSearchClient.getType(), id)
+            IndexResponse response = elasticSearchClient.getClient().prepareIndex(index,
+                    type, id)
                     .setSource(event.getFieldMapPair())
                     .execute()
                     .get();

--- a/data-layers/data-layer-elastic-search/src/main/java/com/flipkart/aesop/processor/es/upsert/ElasticSearchUpsertProcessor.java
+++ b/data-layers/data-layer-elastic-search/src/main/java/com/flipkart/aesop/processor/es/upsert/ElasticSearchUpsertProcessor.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
 
 /**
  * ElasticSearch Upsert Data Layer. Persists {@link DbusOpcode#UPSERT} events to Logs.
@@ -48,16 +47,14 @@ public class ElasticSearchUpsertProcessor extends UpsertDestinationStoreProcesso
         try {
             String id = String.valueOf(event.getFieldMapPair().get("id"));
             //delete if "id" exists
-            String index = isBlank(event.getNamespaceName()) ? elasticSearchClient.getIndex() : event.getNamespaceName();
-            String type = isBlank(event.getEntityName()) ? elasticSearchClient.getType() : event.getEntityName();
 
-            elasticSearchClient.getClient().prepareDelete(index,
-                    type, id)
+            elasticSearchClient.getClient().prepareDelete(event.getNamespaceName(),
+                    event.getEntityName(), id)
                     .execute()
                     .actionGet();
             //create the new id
-            IndexResponse response = elasticSearchClient.getClient().prepareIndex(index,
-                    type, id)
+            IndexResponse response = elasticSearchClient.getClient().prepareIndex(event.getNamespaceName(),
+                    event.getEntityName(), id)
                     .setSource(event.getFieldMapPair())
                     .execute()
                     .get();


### PR DESCRIPTION
@jagadeesh-huliyar @aryaKetan : This gives the ability to push an event to a specific document type in Elasticsearch. The config will be picked from AbstractEvent using these attributes: entityName, namespaceName. It will default to the cluster configuration specified in ElasticSearchConfig otherwise.