### PR TITLE
Resources should be closed

### DIFF
--- a/runtimes/runtime/src/main/java/com/flipkart/aesop/runtime/impl/admin/RuntimeConfigServiceImpl.java
+++ b/runtimes/runtime/src/main/java/com/flipkart/aesop/runtime/impl/admin/RuntimeConfigServiceImpl.java
@@ -268,8 +268,15 @@ public class RuntimeConfigServiceImpl  implements RuntimeConfigService {
 			throw new PlatformException("Unable to create directory structure for uploading file");
 		}
 
-		FileOutputStream fos = new FileOutputStream(destFile);
-		fos.write(fileContents);						
+		FileOutputStream fos = null;
+		try{
+			fos = new FileOutputStream(destFile);
+			fos.write(fileContents);
+		}finally {
+			if(fos != null)
+				fos.close();
+		}
+								
 	}
 	
     /** Getter/Setter methods */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “ Resources should be closed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.