### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/blocking-bootstrap-producers/blocking-bootstrap-mysql-producer/src/main/java/com/flipkart/aesop/bootstrap/mysql/constants/MySQLConstants.java
+++ b/blocking-bootstrap-producers/blocking-bootstrap-mysql-producer/src/main/java/com/flipkart/aesop/bootstrap/mysql/constants/MySQLConstants.java
@@ -56,4 +56,7 @@ public class MySQLConstants
 	public static final int GTID_LOG_EVENT = 33;
 	public static final int ANONYMOUS_GTID_LOG_EVENT = 34;
 	public static final int PREVIOUS_GTIDS_LOG_EVENT = 35;
+
+	private MySQLConstants() {
+	}
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/destinationoperation/utils/DataLayerConstants.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/destinationoperation/utils/DataLayerConstants.java
@@ -26,4 +26,7 @@ public class DataLayerConstants
 	public static final String EQUALTO_AND_COLON = "=:";
 	public static final String AND = " AND ";
 	public static final String PLACEHOLDER = "?";
+
+	private DataLayerConstants() {
+	}
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/destinationoperation/utils/DataLayerHelper.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/destinationoperation/utils/DataLayerHelper.java
@@ -25,6 +25,9 @@ import java.util.Set;
  */
 public class DataLayerHelper
 {
+	private DataLayerHelper() {
+	}
+
 	/**
 	 * Generates a map which has non-primary fields as null.
 	 * @param fieldMap

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/mapper/utils/MapperConstants.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/mapper/utils/MapperConstants.java
@@ -29,4 +29,7 @@ public class MapperConstants
 	public static final String DESTINATION_PRIMARY_KEY_LIST = "primaryKeyList";
 	public static final String EXCLUSION_LIST_FIELD_NAME = "exclusionList";
 	public static final String MAP_ALL_FIELD_NAME = "mapAll";
+
+	private MapperConstants() {
+	}
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/mapper/utils/MapperHelper.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/mapper/utils/MapperHelper.java
@@ -31,6 +31,9 @@ import java.util.Map.Entry;
  */
 public class MapperHelper
 {
+	private MapperHelper() {
+	}
+
 	/**
 	 * Gets Namespace mapAll Path.
 	 * @param configRoot

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/utils/AvroToMysqlMapper.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/utils/AvroToMysqlMapper.java
@@ -31,6 +31,9 @@ public class AvroToMysqlMapper
 	/** Logger for this class */
 	private static final Logger LOGGER = LogFactory.getLogger(AvroToMysqlMapper.class);
 
+	private AvroToMysqlMapper() {
+	}
+
 	/**
 	 * Provides mapping of data from avro to mysql
 	 * @param Object value of avro data type

--- a/data-layers/data-layer-kafka/src/main/java/com/flipkart/aesop/processor/kafka/KafkaDataLayerConstants.java
+++ b/data-layers/data-layer-kafka/src/main/java/com/flipkart/aesop/processor/kafka/KafkaDataLayerConstants.java
@@ -11,4 +11,7 @@ public final class KafkaDataLayerConstants {
     public static final String OPCODE = "OPCODE";
 
     public static final String DEFAULT_KAFKA_SUFFIX = ".topic";
+
+    private KafkaDataLayerConstants() {
+    }
 }

--- a/producers/diff-producer/src/main/java/com/flipkart/aesop/serializer/SerializerConstants.java
+++ b/producers/diff-producer/src/main/java/com/flipkart/aesop/serializer/SerializerConstants.java
@@ -40,5 +40,7 @@ public class SerializerConstants {
 	/** The Date format instances for used in naming files and state engine versions*/
 	public static SimpleDateFormat DAILY_DIR_FORMAT = new SimpleDateFormat(DAILY_DIR_FORMAT_STRING);
 	public static SimpleDateFormat DAILY_FILE_FORMAT = new SimpleDateFormat(DAILY_FILE_FORMAT_STRING);
-		
+
+	private SerializerConstants() {
+	}
 }

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/constants/MySQLConstants.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/constants/MySQLConstants.java
@@ -59,4 +59,6 @@ public final class MySQLConstants {
 	public static final int ANONYMOUS_GTID_LOG_EVENT = 34;
 	public static final int PREVIOUS_GTIDS_LOG_EVENT = 35;
 
+	private MySQLConstants() {
+	}
 }

--- a/runtimes/runtime-snapshot-serializer/src/main/java/com/flipkart/aesop/serializer/SerializerConstants.java
+++ b/runtimes/runtime-snapshot-serializer/src/main/java/com/flipkart/aesop/serializer/SerializerConstants.java
@@ -40,5 +40,7 @@ public class SerializerConstants {
 	/** The Date format instances for used in naming files and state engine versions*/
 	public static SimpleDateFormat DAILY_DIR_FORMAT = new SimpleDateFormat(DAILY_DIR_FORMAT_STRING);
 	public static SimpleDateFormat DAILY_FILE_FORMAT = new SimpleDateFormat(DAILY_FILE_FORMAT_STRING);
-		
+
+	private SerializerConstants() {
+	}
 }

--- a/runtimes/runtime/src/main/java/com/flipkart/aesop/runtime/RuntimeFrameworkConstants.java
+++ b/runtimes/runtime/src/main/java/com/flipkart/aesop/runtime/RuntimeFrameworkConstants.java
@@ -28,5 +28,7 @@ public class RuntimeFrameworkConstants {
 	 */
 	public static final String COMMON_RUNTIME_CONFIG = "packaged/common-runtime-config.xml"; // its a file picked up from classpath
 	public static final String COMMON_RUNTIME_SERVER_NATURE_CONFIG = "packaged/common-runtime-server-nature-config.xml"; // its a file picked up from classpath
-	
+
+	private RuntimeFrameworkConstants() {
+	}
 }

--- a/samples/sample-client-common/src/main/java/com/flipkart/aesop/sample/client/common/utils/AvroToMysqlMapper.java
+++ b/samples/sample-client-common/src/main/java/com/flipkart/aesop/sample/client/common/utils/AvroToMysqlMapper.java
@@ -16,6 +16,9 @@ public class AvroToMysqlMapper
 	/** Logger for this class */
 	private static final Logger LOGGER = LogFactory.getLogger(AvroToMysqlMapper.class);
 
+	private AvroToMysqlMapper() {
+	}
+
 	/**
 	 * Provides mapping of data from avro to mysql
 	 * @param Object value of avro data type

--- a/samples/sample-hbase-relay/src/test/java/com/flipkart/aesop/relay/hbase/SchemaSetupMain.java
+++ b/samples/sample-hbase-relay/src/test/java/com/flipkart/aesop/relay/hbase/SchemaSetupMain.java
@@ -33,7 +33,10 @@ import org.apache.hadoop.hbase.client.HBaseAdmin;
  * 
  */
 public class SchemaSetupMain {
-	
+
+	private SchemaSetupMain() {
+	}
+
 	public static void main(String[] args) throws Exception {
 		Configuration conf = HBaseConfiguration.create();
 		createSchema(conf);

--- a/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/main/SchemaGeneratorCli.java
+++ b/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/main/SchemaGeneratorCli.java
@@ -29,6 +29,9 @@ import com.flipkart.aesop.avro.schemagenerator.mysql.DataSourceConfig;
 
 public class SchemaGeneratorCli
 {
+	private SchemaGeneratorCli() {
+	}
+
 	public static void main(String[] commandLineArguments)
 	{
 		final CommandLineParser cmdLineGnuParser = new GnuParser();

--- a/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/mysql/MysqlUtils.java
+++ b/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/mysql/MysqlUtils.java
@@ -28,6 +28,9 @@ public class MysqlUtils
 	private static final String FIELDS_DETAILS_FETCH_QUERY =
 	        "SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? and TABLE_NAME = ?";
 
+	private MysqlUtils() {
+	}
+
 	/**
 	 * Release db resource.
 	 * @param connection object


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “  Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.