### PR TITLE
Added Timestamp2Column and Datetime2Column for timestamp and datetime for Open Replicator events

### DIFF
--- a/blocking-bootstrap-producers/blocking-bootstrap-mysql-producer/src/main/java/com/flipkart/aesop/bootstrap/mysql/utils/ORToMysqlMapper.java
+++ b/blocking-bootstrap-producers/blocking-bootstrap-mysql-producer/src/main/java/com/flipkart/aesop/bootstrap/mysql/utils/ORToMysqlMapper.java
@@ -15,33 +15,16 @@ package com.flipkart.aesop.bootstrap.mysql.utils;
 
 import java.nio.charset.Charset;
 import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
 
+import com.google.code.or.common.glossary.column.*;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
 import com.flipkart.aesop.bootstrap.mysql.MysqlEventProducer;
 import com.google.code.or.common.glossary.Column;
-import com.google.code.or.common.glossary.column.BitColumn;
-import com.google.code.or.common.glossary.column.BlobColumn;
-import com.google.code.or.common.glossary.column.DateColumn;
-import com.google.code.or.common.glossary.column.DatetimeColumn;
-import com.google.code.or.common.glossary.column.DecimalColumn;
-import com.google.code.or.common.glossary.column.DoubleColumn;
-import com.google.code.or.common.glossary.column.EnumColumn;
-import com.google.code.or.common.glossary.column.FloatColumn;
-import com.google.code.or.common.glossary.column.Int24Column;
-import com.google.code.or.common.glossary.column.LongColumn;
-import com.google.code.or.common.glossary.column.LongLongColumn;
-import com.google.code.or.common.glossary.column.NullColumn;
-import com.google.code.or.common.glossary.column.SetColumn;
-import com.google.code.or.common.glossary.column.ShortColumn;
-import com.google.code.or.common.glossary.column.StringColumn;
-import com.google.code.or.common.glossary.column.TimeColumn;
-import com.google.code.or.common.glossary.column.TimestampColumn;
-import com.google.code.or.common.glossary.column.TinyColumn;
-import com.google.code.or.common.glossary.column.YearColumn;
 
 /**
  * <code>ORToMysqlMapper</code> provides mapping of data from open replicator data type to mysql data type
@@ -82,6 +65,11 @@ public class ORToMysqlMapper
 			 */
 			return new java.sql.Timestamp((date.getTime() / 1000) * 1000);
 		}
+        else if (column instanceof Datetime2Column) {
+            Datetime2Column datetime2Column = (Datetime2Column) column;
+            Date date = datetime2Column.getValue();
+            return new java.sql.Timestamp((date.getTime() / 1000) * 1000);
+        }
 		else if (column instanceof DecimalColumn)
 		{
 			DecimalColumn decimalColumn = (DecimalColumn) column;
@@ -160,6 +148,10 @@ public class ORToMysqlMapper
 			TimestampColumn timeStampColumn = (TimestampColumn) column;
 			return timeStampColumn.getValue();
 		}
+        else if (column instanceof Timestamp2Column){
+            Timestamp2Column timeStampColumn = (Timestamp2Column) column;
+            return timeStampColumn.getValue();
+        }
 		else if (column instanceof TinyColumn)
 		{
 			TinyColumn tinyColumn = (TinyColumn) column;

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/mapper/impl/ORToAvroMapper.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/mapper/impl/ORToAvroMapper.java
@@ -22,29 +22,11 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
 
+import com.google.code.or.common.glossary.column.*;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
 import com.google.code.or.common.glossary.Column;
-import com.google.code.or.common.glossary.column.BitColumn;
-import com.google.code.or.common.glossary.column.BlobColumn;
-import com.google.code.or.common.glossary.column.DateColumn;
-import com.google.code.or.common.glossary.column.DatetimeColumn;
-import com.google.code.or.common.glossary.column.DecimalColumn;
-import com.google.code.or.common.glossary.column.DoubleColumn;
-import com.google.code.or.common.glossary.column.EnumColumn;
-import com.google.code.or.common.glossary.column.FloatColumn;
-import com.google.code.or.common.glossary.column.Int24Column;
-import com.google.code.or.common.glossary.column.LongColumn;
-import com.google.code.or.common.glossary.column.LongLongColumn;
-import com.google.code.or.common.glossary.column.NullColumn;
-import com.google.code.or.common.glossary.column.SetColumn;
-import com.google.code.or.common.glossary.column.ShortColumn;
-import com.google.code.or.common.glossary.column.StringColumn;
-import com.google.code.or.common.glossary.column.TimeColumn;
-import com.google.code.or.common.glossary.column.TimestampColumn;
-import com.google.code.or.common.glossary.column.TinyColumn;
-import com.google.code.or.common.glossary.column.YearColumn;
 import com.linkedin.databus.core.DatabusRuntimeException;
 import com.linkedin.databus2.core.DatabusException;
 /**
@@ -133,7 +115,15 @@ public class ORToAvroMapper {
 			TimestampColumn timeStampColumn = (TimestampColumn) column;
 			Timestamp timeStamp = timeStampColumn.getValue();
 			return timeStamp.getTime();
-		}else if (column instanceof TinyColumn){
+		}else if (column instanceof Timestamp2Column){
+            Timestamp2Column timeStampColumn = (Timestamp2Column) column;
+            Timestamp timeStamp = timeStampColumn.getValue();
+            return timeStamp.getTime();
+        }else if (column instanceof Datetime2Column){
+            Datetime2Column datetime2Column = (Datetime2Column) column;
+            Date date = datetime2Column.getValue();
+            return (date.getTime()/1000) * 1000;
+        } else if (column instanceof TinyColumn){
 			TinyColumn tinyColumn = (TinyColumn) column;
 			return tinyColumn.getValue();
 		}else if (column instanceof YearColumn){


### PR DESCRIPTION
New version of open replicator use Datetime2Column and Timestamp2Column for OR events of datetime and timestamp respectively.