### PR TITLE
Aesop Patch to send old values from mysql producer

### DIFF
--- a/blocking-bootstrap-producers/blocking-bootstrap-mysql-producer/src/main/java/com/flipkart/aesop/bootstrap/mysql/mapper/impl/DefaultBinLogEventMapper.java
+++ b/blocking-bootstrap-producers/blocking-bootstrap-mysql-producer/src/main/java/com/flipkart/aesop/bootstrap/mysql/mapper/impl/DefaultBinLogEventMapper.java
@@ -86,7 +86,7 @@ public class DefaultBinLogEventMapper<T extends AbstractEvent> implements BinLog
 			}
 
 			return (T)new SourceEvent(keyValuePairs, getPkListFromSchema(schema), schema.getName(), schema.getNamespace(),
-			        eventType);
+			        eventType, null);
 		}
 		catch (Exception e)
 		{

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/AbstractEvent.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/AbstractEvent.java
@@ -39,22 +39,27 @@ public abstract class AbstractEvent implements Event
 	/** Event Type. */
 	protected final DbusOpcode eventType;
 
+	/** OldRowMap : Storing changes.
+	 * This field holds field Change values (old values) */
+	protected final Map<String, Object> rowChangeMap;
+
 	/**
 	 * Constructs the basic event using mandatory fields.
-	 * @param fieldsMap
+	 * @param fieldMap
 	 * @param primaryKeysSet
 	 * @param entityName
 	 * @param namespaceName
 	 * @param eventType
+	 * @param rowChangeMap
 	 */
-	public AbstractEvent(Map<String, Object> fieldsMap, Set<String> primaryKeysSet, String entityName,
-	        String namespaceName, DbusOpcode eventType)
-	{
-		this.fieldMap = fieldsMap;
+	public AbstractEvent(Map<String, Object> fieldMap, Set<String> primaryKeysSet, String entityName,
+						 String namespaceName, DbusOpcode eventType, Map<String, Object> rowChangeMap) {
+		this.fieldMap = fieldMap;
 		this.primaryKeysSet = primaryKeysSet;
 		this.entityName = entityName;
 		this.namespaceName = namespaceName;
 		this.eventType = eventType;
+		this.rowChangeMap = rowChangeMap;
 	}
 
 	public Map<String, Object> getFieldMapPair()
@@ -102,10 +107,14 @@ public abstract class AbstractEvent implements Event
 		return primaryKeyValues;
 	}
 
+	public Map<String, Object> getRowChangeMap() {
+		return rowChangeMap;
+	}
+
 	@Override
 	public String toString()
 	{
 		return "AbstractEvent [fieldsMap=" + fieldMap + ", primaryKeysSet=" + primaryKeysSet + ", entityName="
-		        + entityName + ", namespaceName=" + namespaceName + ", eventType=" + eventType + "]";
+		        + entityName + ", namespaceName=" + namespaceName + ", eventType=" + eventType + ", rowChangeMap=" + rowChangeMap + "]";
 	}
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/AbstractEventFactory.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/AbstractEventFactory.java
@@ -10,29 +10,25 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *  
+ *
  *******************************************************************************/
 
 package com.flipkart.aesop.event;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.flipkart.aesop.utils.AvroSchemaHelper;
+import com.flipkart.aesop.utils.AvroToMysqlConverter;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericRecord;
-
-import com.flipkart.aesop.utils.AvroToMysqlMapper;
-import com.flipkart.aesop.utils.MysqlDataTypes;
 import com.linkedin.databus.client.pub.DbusEventDecoder;
-import com.linkedin.databus.core.DbusConstants;
 import com.linkedin.databus.core.DbusEvent;
 import com.linkedin.databus.core.DbusOpcode;
 import com.linkedin.databus2.core.DatabusException;
 import com.linkedin.databus2.schemas.VersionedSchema;
-import com.linkedin.databus2.schemas.utils.SchemaHelper;
 
 /**
  * Abstract Event Factory to be extended by the various types of Event Factory Classes.
@@ -41,50 +37,36 @@ import com.linkedin.databus2.schemas.utils.SchemaHelper;
  */
 public abstract class AbstractEventFactory<T extends AbstractEvent> implements EventFactory
 {
-	public static String PRIMARY_KEY_FIELD_NAME = "pk";
-	public static String META_FIELD_TYPE_NAME = "dbFieldType";
-
-	/**
-	 * Generates primary key set using the schema.
-	 * @param schema
-	 * @return Primary key set
-	 * @throws DatabusException
-	 */
-	private Set<String> getPrimaryKeysSetFromSchema(Schema schema) throws DatabusException
-	{
-		Set<String> primaryKeySet = new HashSet<String>();
-		String primaryKeyFieldName = SchemaHelper.getMetaField(schema, PRIMARY_KEY_FIELD_NAME);
-		if (primaryKeyFieldName == null)
-		{
-			throw new DatabusException("No primary key specified in the schema");
-		}
-		for (String primaryKey : primaryKeyFieldName.split(DbusConstants.COMPOUND_KEY_SEPARATOR))
-		{
-			primaryKeySet.add(primaryKey.trim());
-		}
-		assert (primaryKeySet.size() >= 1);
-		return primaryKeySet;
-	}
-
 	public AbstractEvent createEvent(DbusEvent dbusEvent, DbusEventDecoder eventDecoder) throws DatabusException
 	{
 		GenericRecord genericRecord = eventDecoder.getGenericRecord(dbusEvent, null);
 		VersionedSchema writerSchema = eventDecoder.getPayloadSchema(dbusEvent);
 		Schema schema = writerSchema.getSchema();
 		DbusOpcode eventType = dbusEvent.getOpcode();
-		Set<String> primaryKeysSet = getPrimaryKeysSetFromSchema(schema);
+		Set<String> primaryKeysSet = AvroSchemaHelper.getPrimaryKeysSetFromSchema(schema);
 		String namespaceName = schema.getNamespace();
 		String entityName = schema.getName();
 		Map<String, Object> fieldMap = new HashMap<String, Object>();
+		Map <String, String> fieldToMysqlDataType = AvroSchemaHelper.fieldToDataTypeMap(schema);
+		String rowChangeField = AvroSchemaHelper.getRowChangeField(schema);
+		Map<String, Object> rowChangeMap = null;
+
 		for (Field field : schema.getFields())
 		{
-			String mysqlType = SchemaHelper.getMetaField(field, META_FIELD_TYPE_NAME);
-			fieldMap.put(
-			        field.name(),
-			        AvroToMysqlMapper.avroToMysqlType(genericRecord.get(field.name()),
-			                MysqlDataTypes.valueOf(mysqlType.toUpperCase())));
+			Object recordValue = genericRecord.get(field.name());
+			if (field.name().equals(rowChangeField))
+			{
+				rowChangeMap = AvroToMysqlConverter.getMysqlTypedObjectForMap((Map<Object, Object>) recordValue,
+						fieldToMysqlDataType);
+			}
+			else
+			{
+				fieldMap.put(field.name(),
+						AvroToMysqlConverter.getMysqlTypedObject(fieldToMysqlDataType.get(field.name()), recordValue));
+			}
 		}
-		AbstractEvent event = createEventInstance(fieldMap, primaryKeysSet, entityName, namespaceName, eventType);
+		AbstractEvent event = createEventInstance(fieldMap, primaryKeysSet, entityName, namespaceName, eventType,
+				rowChangeMap);
 		return event;
 	}
 
@@ -98,23 +80,25 @@ public abstract class AbstractEventFactory<T extends AbstractEvent> implements E
 	 * @return Actual Event instance.
 	 */
 	protected abstract AbstractEvent createEventInstance(Map<String, Object> fieldsMap, Set<String> primaryKeysSet,
-	        String entityName, String namespaceName, DbusOpcode eventType);
+														 String entityName, String namespaceName, DbusOpcode eventType, Map<String, Object> rowChangeMap);
 
-	public AbstractEvent createEvent(Schema schema, Map<String, Object> keyValuePairs, DbusOpcode eventType)
-	        throws DatabusException
+	public AbstractEvent createEvent(Schema schema, Map<String, Object> keyValuePairs, DbusOpcode eventType, Map<String, Object> rowChangeMap)
+			throws DatabusException
 	{
 		String entityName = schema.getName();
 		String namespaceName = schema.getNamespace();
-		Set<String> primaryKeysSet = getPrimaryKeysSetFromSchema(schema);
+		Set<String> primaryKeysSet = AvroSchemaHelper.getPrimaryKeysSetFromSchema(schema);
 
-		AbstractEvent event = createEventInstance(keyValuePairs, primaryKeysSet, entityName, namespaceName, eventType);
+		AbstractEvent event =
+				createEventInstance(keyValuePairs, primaryKeysSet, entityName, namespaceName, eventType, rowChangeMap);
 		return event;
 	}
 
 	public AbstractEvent createEvent(Map<String, Object> fieldsMap, Set<String> primaryFieldsSet, String entityName,
-	        String namespaceName, DbusOpcode eventType)
+									 String namespaceName, DbusOpcode eventType, Map<String, Object> rowChangeMap)
 	{
-		AbstractEvent event = createEventInstance(fieldsMap, primaryFieldsSet, entityName, namespaceName, eventType);
+		AbstractEvent event =
+				createEventInstance(fieldsMap, primaryFieldsSet, entityName, namespaceName, eventType, rowChangeMap);
 
 		return event;
 	}

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/Event.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/Event.java
@@ -76,4 +76,10 @@ public interface Event
 	 * @return {@link List} of Primary Keys
 	 */
 	public List<Object> getPrimaryKeyValues();
+
+	/**
+	 * Gets the change Map which store old values of record.
+	 * @return rowChangeMap
+	 */
+	public Map<String, Object> getRowChangeMap();
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/EventFactory.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/EventFactory.java
@@ -51,7 +51,8 @@ public interface EventFactory
 	 * @return {@link AbstractEvent}
 	 * @throws DatabusException
 	 */
-	public AbstractEvent createEvent(Schema schema, Map<String, Object> fieldMap, DbusOpcode eventType)
+	public AbstractEvent createEvent(Schema schema, Map<String, Object> fieldMap, DbusOpcode eventType,
+									 Map<String, Object> rowChangeMap)
 	        throws DatabusException;
 
 	/**
@@ -61,8 +62,9 @@ public interface EventFactory
 	 * @param entityName
 	 * @param namespaceName
 	 * @param eventType
+	 * @param rowChangeMap
 	 * @return {@link AbstractEvent}
 	 */
 	public AbstractEvent createEvent(Map<String, Object> fieldsMap, Set<String> primaryFieldsSet, String entityName,
-	        String namespaceName, DbusOpcode eventType);
+									 String namespaceName, DbusOpcode eventType, Map<String, Object> rowChangeMap);
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/implementation/DestinationEvent.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/implementation/DestinationEvent.java
@@ -36,10 +36,11 @@ public class DestinationEvent extends AbstractEvent
 	 * @param entityName
 	 * @param namespaceName
 	 * @param eventType
+	 * @param rowChangeMap
 	 */
 	public DestinationEvent(Map<String, Object> fieldsMap, Set<String> primaryKeysSet, String entityName,
-	        String namespaceName, DbusOpcode eventType)
+	        String namespaceName, DbusOpcode eventType, Map<String, Object> rowChangeMap)
 	{
-		super(fieldsMap, primaryKeysSet, entityName, namespaceName, eventType);
+		super(fieldsMap, primaryKeysSet, entityName, namespaceName, eventType, rowChangeMap);
 	}
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/implementation/DestinationEventFactory.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/implementation/DestinationEventFactory.java
@@ -29,8 +29,8 @@ public class DestinationEventFactory extends AbstractEventFactory<DestinationEve
 {
 	@Override
 	protected DestinationEvent createEventInstance(Map<String, Object> fieldsMap, Set<String> primaryKeysSet,
-	        String entityName, String namespaceName, DbusOpcode eventType)
+	        String entityName, String namespaceName, DbusOpcode eventType, Map<String, Object> rowChangeMap)
 	{
-		return new DestinationEvent(fieldsMap, primaryKeysSet, entityName, namespaceName, eventType);
+		return new DestinationEvent(fieldsMap, primaryKeysSet, entityName, namespaceName, eventType, rowChangeMap);
 	}
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/implementation/SourceEvent.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/implementation/SourceEvent.java
@@ -36,10 +36,11 @@ public class SourceEvent extends AbstractEvent
 	 * @param entityName
 	 * @param namespaceName
 	 * @param eventType
+	 * @param rowChangeMap
 	 */
 	public SourceEvent(Map<String, Object> fieldsMap, Set<String> primaryKeysSet, String entityName,
-	        String namespaceName, DbusOpcode eventType)
+	        String namespaceName, DbusOpcode eventType, Map<String, Object> rowChangeMap)
 	{
-		super(fieldsMap, primaryKeysSet, entityName, namespaceName, eventType);
+		super(fieldsMap, primaryKeysSet, entityName, namespaceName, eventType, rowChangeMap);
 	}
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/implementation/SourceEventFactory.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/event/implementation/SourceEventFactory.java
@@ -18,6 +18,7 @@ package com.flipkart.aesop.event.implementation;
 import java.util.Map;
 import java.util.Set;
 
+import com.flipkart.aesop.event.AbstractEvent;
 import com.flipkart.aesop.event.AbstractEventFactory;
 import com.linkedin.databus.core.DbusOpcode;
 
@@ -29,8 +30,8 @@ public class SourceEventFactory extends AbstractEventFactory<SourceEvent>
 {
 	@Override
 	protected SourceEvent createEventInstance(Map<String, Object> fieldsMap, Set<String> primaryKeysSet,
-	        String entityName, String namespaceName, DbusOpcode eventType)
+	        String entityName, String namespaceName, DbusOpcode eventType,  Map<String, Object> rowChangeMap)
 	{
-		return new SourceEvent(fieldsMap, primaryKeysSet, entityName, namespaceName, eventType);
+		return new SourceEvent(fieldsMap, primaryKeysSet, entityName, namespaceName, eventType, rowChangeMap);
 	}
 }

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/mapper/implementation/MapperType.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/mapper/implementation/MapperType.java
@@ -70,7 +70,8 @@ public enum MapperType
 
 			AbstractEvent destinationEvent =
 			        destinationEventFactory.createEvent(sourceEvent.getFieldMapPair(), sourceEvent.getPrimaryKeySet(),
-			                sourceEvent.getEntityName(), sourceEvent.getNamespaceName(), sourceEvent.getEventType());
+			                sourceEvent.getEntityName(), sourceEvent.getNamespaceName(), sourceEvent.getEventType(),
+					        sourceEvent.getRowChangeMap());
 
 			return Arrays.asList(destinationEvent);
 		}
@@ -106,7 +107,7 @@ public enum MapperType
 
 			AbstractEvent destinationEvent =
 			        destinationEventFactory.createEvent(sourceEvent.getFieldMapPair(), sourceEvent.getPrimaryKeySet(),
-			                sourceEvent.getEntityName(), sourceEvent.getNamespaceName(), sourceEvent.getEventType());
+			                sourceEvent.getEntityName(), sourceEvent.getNamespaceName(), sourceEvent.getEventType(), sourceEvent.getRowChangeMap());
 
 			return Arrays.asList(destinationEvent);
 		}
@@ -170,7 +171,8 @@ public enum MapperType
 
 				AbstractEvent destinationEvent =
 				        destinationEventFactory.createEvent(destinationEventColumnMap, primaryKeySet,
-				                destinationEntity, destinationNamespace, sourceEvent.getEventType());
+				                destinationEntity, destinationNamespace, sourceEvent.getEventType(),
+								sourceEvent.getRowChangeMap());
 
 				destinationEventList.add(destinationEvent);
 			}

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/utils/AvroSchemaHelper.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/utils/AvroSchemaHelper.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *
+ * Copyright 2012-2015, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obta a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+
+package com.flipkart.aesop.utils;
+
+import com.linkedin.databus.core.DbusConstants;
+import com.linkedin.databus2.core.DatabusException;
+import com.linkedin.databus2.schemas.utils.SchemaHelper;
+import org.apache.avro.Schema;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class AvroSchemaHelper
+{
+	private static final String META_ROW_CHANGE_FIELD = "rowChangeField";
+	private static final String META_FIELD_TYPE_NAME = "dbFieldType";
+	private static final String PRIMARY_KEY_FIELD_NAME = "pk";
+
+	/**
+	 * Returns the fieldname marked as row change field from schema meta
+	 * @param schema
+	 * @return rowChangeFieldName
+	 */
+	public static String getRowChangeField(Schema schema)
+	{
+		return SchemaHelper.getMetaField(schema, META_ROW_CHANGE_FIELD);
+	}
+
+	/**
+	 * Generates a hash storing fieldName to intended MysqlDataType from schema
+	 * @param schema
+	 * @return Map containg FieldName to Mysql Type mapping
+	 */
+	public static Map<String, String> fieldToDataTypeMap(Schema schema)
+	{
+		Map<String, String> map = new HashMap <String, String>();
+		for (Schema.Field field : schema.getFields())
+		{
+			String mysqlType = SchemaHelper.getMetaField(field, META_FIELD_TYPE_NAME);
+			map.put(field.name(), mysqlType);
+		}
+		return map;
+	}
+
+	/**
+	 * Generates primary key set using the schema.
+	 * @param schema
+	 * @return Primary key set
+	 * @throws DatabusException
+	 */
+	public static Set<String> getPrimaryKeysSetFromSchema(Schema schema) throws DatabusException
+	{
+		String primaryKeyFieldName = SchemaHelper.getMetaField(schema, PRIMARY_KEY_FIELD_NAME);
+		if (primaryKeyFieldName == null)
+		{
+			throw new DatabusException("No primary key specified in the schema");
+		}
+
+		Set<String> primaryKeySet = new HashSet<String>();
+		for (String primaryKey : primaryKeyFieldName.split(DbusConstants.COMPOUND_KEY_SEPARATOR))
+		{
+			primaryKeySet.add(primaryKey.trim());
+		}
+		assert (primaryKeySet.size() >= 1);
+		return primaryKeySet;
+	}
+}
+

--- a/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/utils/AvroToMysqlConverter.java
+++ b/consumers/client-event-consumer/src/main/java/com/flipkart/aesop/utils/AvroToMysqlConverter.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ *
+ * Copyright 2012-2015, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obta a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+
+package com.flipkart.aesop.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class AvroToMysqlConverter
+{
+    /**
+   	 * This returns mysql object from avro object and intended mysql datatype
+   	 * @param mysqlType
+   	 * @param fieldValue
+   	 * @return MysqlTypedObject using AvroToMysqlMapper
+   	 */
+   	public static Object getMysqlTypedObject(String mysqlType, Object fieldValue)
+   	{
+   		return AvroToMysqlMapper.avroToMysqlType(fieldValue, MysqlDataTypes.valueOf(mysqlType.toUpperCase()));
+   	}
+
+   	/**
+   	 * This specifically handles rowChangeField which comes in form HashMap and converting each key/value to Mysql type
+   	 * @param fieldMap
+   	 * @param fieldToMysqlDataType
+   	 * @return MysqlTypedObject using AvroToMysqlMapper
+   	 */
+   	public static Map<String, Object> getMysqlTypedObjectForMap(Map<Object, Object> fieldMap,
+                                                         Map<String, String> fieldToMysqlDataType)
+   	{
+   		Map<String, Object> mysqlTypedObject = null;
+   		if (fieldMap != null)
+   		{
+   			mysqlTypedObject = new HashMap<String, Object>(fieldMap.size());
+   			for (Object key : fieldMap.keySet())
+   			{
+   				String fieldName = key.toString();
+   				String sqlType = fieldToMysqlDataType.get(fieldName);
+   				mysqlTypedObject.put(fieldName, AvroToMysqlConverter.getMysqlTypedObject(sqlType, fieldMap.get(key)));
+   			}
+   		}
+   		return mysqlTypedObject;
+   	}
+}

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/MysqlEventProducer.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/MysqlEventProducer.java
@@ -75,7 +75,12 @@ public class MysqlEventProducer<T extends GenericRecord> extends AbstractEventPr
 	protected SchemaChangeEventProcessor schemaChangeEventProcessor;
 	/** The SCN generator implementation, initialized to the default simple implementation*/
 	protected SCNGenerator scnGenerator = new NaiveSCNGenerator();
+	/** Stores the flag value for propogating old/changed row values. Defaulting it to false */
+	private boolean oldValueRequired;
 
+	public void setOldValueRequired(boolean oldValueRequired) {
+		this.oldValueRequired = oldValueRequired;
+	}
 	/**
 	 * Interface method implementation. Checks for mandatory dependencies and creates the Open Replicator
 	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
@@ -181,7 +186,7 @@ public class MysqlEventProducer<T extends GenericRecord> extends AbstractEventPr
 	        PhysicalSourceStaticConfig pConfig) throws DatabusException, EventCreationException,
 	        UnsupportedKeyException, InvalidConfigException
 	{
-		MysqlAvroEventManager<T> manager = new MysqlAvroEventManager<T>(sourceConfig.getId(), (short) pConfig.getId());
+		MysqlAvroEventManager<T> manager = new MysqlAvroEventManager<T>(sourceConfig.getId(), (short) pConfig.getId(), this.oldValueRequired);
 		return manager;
 	}
 

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/avro/exception/InvalidAvroSchemaException.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/avro/exception/InvalidAvroSchemaException.java
@@ -1,0 +1,21 @@
+package com.flipkart.aesop.runtime.producer.avro.exception;
+
+/**
+ * Created by akshit.agarwal on 19/04/16.
+ */
+
+public class InvalidAvroSchemaException extends RuntimeException
+{
+    public InvalidAvroSchemaException() {
+    }
+
+    public InvalidAvroSchemaException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public InvalidAvroSchemaException(String message) {
+        super(message);
+    }
+    public InvalidAvroSchemaException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/avro/utils/AvroSchemaHelper.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/avro/utils/AvroSchemaHelper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015, the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.aesop.runtime.producer.avro.utils;
+
+import com.linkedin.databus2.schemas.utils.SchemaHelper;
+import org.apache.avro.Schema;
+import java.util.List;
+
+/**
+ * Created by akshit.agarwal on 14/03/16.
+ */
+public abstract class AvroSchemaHelper
+{
+    private static final String ROW_CHANGE_META_FIELD = "rowChangeField";
+
+    /**
+     * @param schema
+     * @return Fieldname representing row change
+     */
+    public static String getRowChangeField(Schema schema)
+    {
+        return SchemaHelper.getMetaField(schema, ROW_CHANGE_META_FIELD);
+    }
+}

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/DeleteEventV2Processor.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/DeleteEventV2Processor.java
@@ -1,5 +1,7 @@
 package com.flipkart.aesop.runtime.producer.eventprocessor.impl;
 
+import com.google.code.or.common.glossary.Pair;
+import com.google.code.or.common.glossary.Row;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
@@ -8,6 +10,9 @@ import com.flipkart.aesop.runtime.producer.eventprocessor.BinLogEventProcessor;
 import com.google.code.or.binlog.BinlogEventV4;
 import com.google.code.or.binlog.impl.event.DeleteRowsEventV2;
 import com.linkedin.databus.core.DbusOpcode;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The <code>DeleteEventV2Processor</code> processes DeleteRowsEventV2 from source. This event gets called when ever few
@@ -28,14 +33,23 @@ public class DeleteEventV2Processor implements BinLogEventProcessor
 	{
 		if (!listener.getMysqlTransactionManager().isBeginTxnSeen())
 		{
-			LOGGER.warn("Skipping event (" + event + ") as this is before the start of first transaction");
+			LOGGER.warn("Skipping event ({}) as this is before the start of first transaction", event);
 			return;
 		}
-		LOGGER.debug("Delete Event Received : " + event);
+		LOGGER.debug("Delete Event Received : {}", event);
 		DeleteRowsEventV2 deleteRowsEvent = (DeleteRowsEventV2) event;
+		List<Row> rowList = deleteRowsEvent.getRows();
+		List<Pair<Row>> listOfPairs = new ArrayList<Pair<Row>>(rowList.size());
+
+		for (Row row : rowList)
+		{
+			/* null is added in before to maintain consistency between with update and further in code we dont need to
+			 *differentiate update and delete */
+			listOfPairs.add(new Pair<Row>(null, row));
+		}
+
 		listener.getMysqlTransactionManager().performChanges(deleteRowsEvent.getTableId(), deleteRowsEvent.getHeader(),
-		        deleteRowsEvent.getRows(), DbusOpcode.DELETE);
-		LOGGER.debug("Delete Successful for  " + event.getHeader().getEventLength() + " . Data deleted : "
-		        + deleteRowsEvent.getRows());
+				listOfPairs, DbusOpcode.DELETE);
+		LOGGER.debug("Delete Successful for  {} . Data deleted : {}", event.getHeader().getEventLength(), rowList);
 	}
 }

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/InsertEventProcessor.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/InsertEventProcessor.java
@@ -12,6 +12,8 @@
  */
 package com.flipkart.aesop.runtime.producer.eventprocessor.impl;
 
+import com.google.code.or.common.glossary.Pair;
+import com.google.code.or.common.glossary.Row;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
@@ -20,6 +22,9 @@ import com.flipkart.aesop.runtime.producer.eventprocessor.BinLogEventProcessor;
 import com.google.code.or.binlog.BinlogEventV4;
 import com.google.code.or.binlog.impl.event.WriteRowsEvent;
 import com.linkedin.databus.core.DbusOpcode;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The <code>InsertEventProcessor</code> processes WriteRowsEvent from source. This event is received whenever insertion
@@ -41,15 +46,23 @@ public class InsertEventProcessor implements BinLogEventProcessor
 	{
 		if (!listener.getMysqlTransactionManager().isBeginTxnSeen())
 		{
-			LOGGER.warn("Skipping event (" + event + ") as this is before the start of first transaction");
+			LOGGER.warn("Skipping event ({}) as this is before the start of first transaction", event);
 			return;
 		}
-		LOGGER.debug("Insert Event Received : " + event);
+		LOGGER.debug("Insert Event Received : {}", event);
 		WriteRowsEvent wre = (WriteRowsEvent) event;
-		listener.getMysqlTransactionManager().performChanges(wre.getTableId(), wre.getHeader(), wre.getRows(),
-		        DbusOpcode.UPSERT);
-		LOGGER.debug("Insertion Successful for  " + event.getHeader().getEventLength() + " . Data inserted : "
-		        + wre.getRows());
+		List<Row> rowList = wre.getRows();
+		List<Pair<Row>> listOfPairs = new ArrayList<Pair<Row>>(rowList.size());
+
+		for (Row row : rowList)
+		{
+			//Inserting Old Row as null
+			listOfPairs.add(new Pair<Row>(null, row));
+		}
+
+		listener.getMysqlTransactionManager().performChanges(wre.getTableId(), wre.getHeader(), listOfPairs,
+				DbusOpcode.UPSERT);
+		LOGGER.debug("Insertion Successful for  {} . Data inserted : {}", event.getHeader().getEventLength(), rowList);
 	}
 
 }

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/InsertEventV2Processor.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/InsertEventV2Processor.java
@@ -1,5 +1,7 @@
 package com.flipkart.aesop.runtime.producer.eventprocessor.impl;
 
+import com.google.code.or.common.glossary.Pair;
+import com.google.code.or.common.glossary.Row;
 import org.trpr.platform.core.impl.logging.LogFactory;
 import org.trpr.platform.core.spi.logging.Logger;
 
@@ -8,6 +10,9 @@ import com.flipkart.aesop.runtime.producer.eventprocessor.BinLogEventProcessor;
 import com.google.code.or.binlog.BinlogEventV4;
 import com.google.code.or.binlog.impl.event.WriteRowsEventV2;
 import com.linkedin.databus.core.DbusOpcode;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The <code>InsertEvent2Processor</code> processes WriteRowsEventV2 from source. This event is received if there is any
@@ -28,15 +33,22 @@ public class InsertEventV2Processor implements BinLogEventProcessor
 	{
 		if (!listener.getMysqlTransactionManager().isBeginTxnSeen())
 		{
-			LOGGER.warn("Skipping event (" + event + ") as this is before the start of first transaction");
+			LOGGER.warn("Skipping event ({}) as this is before the start of first transaction", event);
 			return;
 		}
-		LOGGER.debug("Insert Event Received : " + event);
+		LOGGER.debug("Insert Event Received : {}", event);
 		WriteRowsEventV2 wre = (WriteRowsEventV2) event;
-		listener.getMysqlTransactionManager().performChanges(wre.getTableId(), wre.getHeader(), wre.getRows(),
-		        DbusOpcode.UPSERT);
-		LOGGER.debug("Insertion Successful for  " + event.getHeader().getEventLength() + " . Data inserted : "
-		        + wre.getRows());
+		List<Row> rowList = wre.getRows();
+		List<Pair<Row>> listOfPairs = new ArrayList<Pair<Row>>(rowList.size());
+
+		for (Row row : rowList)
+		{
+			listOfPairs.add(new Pair<Row>(null, row));
+		}
+
+		listener.getMysqlTransactionManager().performChanges(wre.getTableId(), wre.getHeader(), listOfPairs,
+				DbusOpcode.UPSERT);
+		LOGGER.debug("Insertion Successful for  {} . Data inserted : {}", event.getHeader().getEventLength(), rowList);
 	}
 
 }

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/UpdateEventProcessor.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/UpdateEventProcessor.java
@@ -12,7 +12,6 @@
  */
 package com.flipkart.aesop.runtime.producer.eventprocessor.impl;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.trpr.platform.core.impl.logging.LogFactory;
@@ -54,13 +53,8 @@ public class UpdateEventProcessor implements BinLogEventProcessor
 		LOGGER.debug("Update Event Received : " + event);
 		UpdateRowsEvent updateRowsEvent = (UpdateRowsEvent) event;
 		List<Pair<Row>> listOfPairs = updateRowsEvent.getRows();
-		List<Row> rowList = new ArrayList<Row>(listOfPairs.size());
-		for (Pair<Row> pair : listOfPairs)
-		{
-			Row row = pair.getAfter();
-			rowList.add(row);
-		}
-		manager.performChanges(updateRowsEvent.getTableId(), updateRowsEvent.getHeader(), rowList, DbusOpcode.UPSERT);
-		LOGGER.debug("Update Successful for  " + event.getHeader().getEventLength() + " . Data updated : " + rowList);
+
+		manager.performChanges(updateRowsEvent.getTableId(), updateRowsEvent.getHeader(), listOfPairs, DbusOpcode.UPSERT);
+		LOGGER.debug("Update Successful for  {} . Data updated : {}", event.getHeader().getEventLength(), listOfPairs);
 	}
 }

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/UpdateEventV2Processor.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/eventprocessor/impl/UpdateEventV2Processor.java
@@ -1,6 +1,5 @@
 package com.flipkart.aesop.runtime.producer.eventprocessor.impl;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.trpr.platform.core.impl.logging.LogFactory;
@@ -42,13 +41,8 @@ public class UpdateEventV2Processor implements BinLogEventProcessor
 		LOGGER.debug("Update Event Received : " + event);
 		UpdateRowsEventV2 updateRowsEvent = (UpdateRowsEventV2) event;
 		List<Pair<Row>> listOfPairs = updateRowsEvent.getRows();
-		List<Row> rowList = new ArrayList<Row>(listOfPairs.size());
-		for (Pair<Row> pair : listOfPairs)
-		{
-			Row row = pair.getAfter();
-			rowList.add(row);
-		}
-		manager.performChanges(updateRowsEvent.getTableId(), updateRowsEvent.getHeader(), rowList, DbusOpcode.UPSERT);
-		LOGGER.debug("Update Successful for  " + event.getHeader().getEventLength() + " . Data updated : " + rowList);
+
+		manager.performChanges(updateRowsEvent.getTableId(), updateRowsEvent.getHeader(), listOfPairs, DbusOpcode.UPSERT);
+		LOGGER.debug("Update Successful for  {} . Data updated : {}", event.getHeader().getEventLength(), listOfPairs);
 	}
 }

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/mapper/impl/DefaultBinLogEventMapper.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/mapper/impl/DefaultBinLogEventMapper.java
@@ -19,6 +19,7 @@ package com.flipkart.aesop.runtime.producer.mapper.impl;
 import java.util.Comparator;
 import java.util.List;
 
+import com.flipkart.aesop.runtime.producer.avro.utils.AvroSchemaHelper;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -78,6 +79,7 @@ public class DefaultBinLogEventMapper<T extends GenericRecord> implements BinLog
 		GenericRecord record = new GenericData.Record(schema);
 		List<Column> columns = row.getColumns();
 		List<Schema.Field> orderedFields;
+		String rowChangeField = AvroSchemaHelper.getRowChangeField(schema);
 
 		try
 		{
@@ -97,7 +99,7 @@ public class DefaultBinLogEventMapper<T extends GenericRecord> implements BinLog
 			int cnt = 0;
 			for (Schema.Field field : orderedFields)
 			{
-				Column column = columns.get(cnt);
+				Column column = field.name().equals(rowChangeField) ? null : columns.get(cnt);
 				record.put(field.name(), column == null ? null : orToAvroMapper.orToAvroType(column));
 				cnt++;
 			}

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/txnprocessor/MysqlTransactionManager.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/txnprocessor/MysqlTransactionManager.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.google.code.or.binlog.BinlogEventV4Header;
 import com.google.code.or.common.glossary.Row;
+import com.google.code.or.common.glossary.Pair;
 import com.linkedin.databus.core.DbusOpcode;
 /**
  * <code>MysqlTransactionManager>/code> defines contracts specific for Mysql transactions. Inherits contracts from {@link TransactionProcessor} and {@link SourceProcessor} 
@@ -28,7 +29,7 @@ import com.linkedin.databus.core.DbusOpcode;
  */
 public interface MysqlTransactionManager extends TransactionProcessor,SourceProcessor{
 	/** Persists change events in event buffer */
-	void performChanges(long tableId,BinlogEventV4Header eventHeader, List<Row> rowList, final DbusOpcode doc);
+	void performChanges(long tableId,BinlogEventV4Header eventHeader, List<Pair<Row>> rowPairs, final DbusOpcode doc);
 	/** Set the current bin log file number*/
 	void setCurrFileNum(int currFileNum) ;
 	/** Get the map of mysqlTableId to tableName mapping */

--- a/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/txnprocessor/impl/MysqlTransactionManagerImpl.java
+++ b/producers/mysql-producer/src/main/java/com/flipkart/aesop/runtime/producer/txnprocessor/impl/MysqlTransactionManagerImpl.java
@@ -18,6 +18,7 @@ import com.flipkart.aesop.runtime.producer.mapper.BinLogEventMapper;
 import com.flipkart.aesop.runtime.producer.spi.SCNGenerator;
 import com.flipkart.aesop.runtime.producer.txnprocessor.MysqlTransactionManager;
 import com.google.code.or.binlog.BinlogEventV4Header;
+import com.google.code.or.common.glossary.Pair;
 import com.google.code.or.common.glossary.Row;
 import com.linkedin.databus.core.DatabusRuntimeException;
 import com.linkedin.databus.core.DbusEventBufferAppendable;
@@ -271,11 +272,11 @@ public class MysqlTransactionManagerImpl<T extends GenericRecord> implements Mys
     /**
      * Persists event related data in transaction object
      * @param eventHeader Binary log event header
-     * @param rowList list of mutated rows
+     * @param listOfPairs list of mutated rows
      * @param databusOpcode operation code indicating nature of change such as insertion,deletion or updation.
      */
     @Override
-    public void performChanges(long tableId, BinlogEventV4Header eventHeader, List<Row> rowList,
+    public void performChanges(long tableId, BinlogEventV4Header eventHeader, List<Pair<Row>> listOfPairs,
                                final DbusOpcode databusOpcode)
     {
         try
@@ -289,7 +290,7 @@ public class MysqlTransactionManagerImpl<T extends GenericRecord> implements Mys
             {
                 List<DbChangeEntry> entries =
                         eventManagerMap.get(Integer.valueOf(tableUriToSrcIdMap.get(currTableName))).frameAvroRecord(
-                                eventHeader, rowList, databusOpcode, binLogEventMappers, schema.getSchema(),
+                                eventHeader, listOfPairs, databusOpcode, binLogEventMappers, schema.getSchema(),
                                 this.scnGenerator.getSCN(frameSCN(currFileNum, (int) eventHeader.getPosition()),
                                         this.mySqlEventProducer.getBinLogHost()));
                 for (DbChangeEntry entry : entries)

--- a/samples/sample-client-common/src/main/java/com/flipkart/aesop/sample/client/common/events/MysqlBinLogEvent.java
+++ b/samples/sample-client-common/src/main/java/com/flipkart/aesop/sample/client/common/events/MysqlBinLogEvent.java
@@ -25,4 +25,6 @@ public interface MysqlBinLogEvent
 
 	public List<Object> getPrimaryKeyValues();
 
+	public Map<String, Object> getRowChangeMap();
+
 }

--- a/samples/sample-mysql-relay/src/main/resources/external/spring-relay-config.xml
+++ b/samples/sample-mysql-relay/src/main/resources/external/spring-relay-config.xml
@@ -35,6 +35,7 @@
         <property name="schemaChangeEventProcessor">
             <bean class="com.flipkart.aesop.runtime.producer.schema.eventprocessor.impl.NopSchemaChangeEventProcessor" />
         </property>
+        <property name="isOldValueRequired" value="false"/>
     </bean>
 
     <bean id="orToAvroMapper" class="com.flipkart.aesop.runtime.producer.mapper.impl.ORToAvroMapper"/>

--- a/samples/sample-mysql-relay/src/main/resources/schemas_registry/com.flipkart.aesop.events.ortest.Person.0.avsc
+++ b/samples/sample-mysql-relay/src/main/resources/schemas_registry/com.flipkart.aesop.events.ortest.Person.0.avsc
@@ -2,27 +2,35 @@
   "name" : "Person",
   "doc" : "Auto-generated Avro schema for sy$person. Generated at Dec 04, 2012 05:07:05 PM PST",
   "type" : "record",
-  "meta" : "dbFieldName=person;pk=id;",
+  "meta" : "dbFieldName=person;pk=id;rowChangeField=_oldValue",
   "namespace" : "or_test",
   "fields" : [ {
     "name" : "id",
     "type" : [ "long", "null" ],
-    "meta" : "dbFieldName=ID;dbFieldPosition=0;dbFieldType=bigint"
+    "meta" : "dbFieldName=ID;dbFieldPosition=1;dbFieldType=bigint"
   }, {
     "name" : "firstName",
     "type" : [ "string", "null" ],
-    "meta" : "dbFieldName=FIRST_NAME;dbFieldPosition=1;dbFieldType=varchar"
+    "meta" : "dbFieldName=FIRST_NAME;dbFieldPosition=2;dbFieldType=varchar"
   }, {
     "name" : "lastName",
     "type" : [ "string", "null" ],
-    "meta" : "dbFieldName=LAST_NAME;dbFieldPosition=2;dbFieldType=varchar"
+    "meta" : "dbFieldName=LAST_NAME;dbFieldPosition=3;dbFieldType=varchar"
   }, {
     "name" : "birthDate",
     "type" : [ "long", "null" ],
-    "meta" : "dbFieldName=BIRTH_DATE;dbFieldPosition=3;dbFieldType=timestamp"
+    "meta" : "dbFieldName=BIRTH_DATE;dbFieldPosition=4;dbFieldType=timestamp"
   }, {
     "name" : "deleted",
     "type" : [ "string", "null" ],
-    "meta" : "dbFieldName=DELETED;dbFieldPosition=4;dbFieldType=varchar"
-  } ]
+    "meta" : "dbFieldName=DELETED;dbFieldPosition=5;dbFieldType=varchar"
+  }, {
+       "name" : "_oldValue",
+       "type" : [ {
+         "values" : [ "int", "long", "float", "double", "bytes", "string", "null" ],
+         "type" : "map"
+       }, "null" ],
+       "meta" : "dbFieldName=_oldValue;dbFieldPosition=6;dbFieldType=MAP"
+  }
+  ]
 }

--- a/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/data/MysqlToAvroMapper.java
+++ b/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/data/MysqlToAvroMapper.java
@@ -1,5 +1,9 @@
 package com.flipkart.aesop.avro.schemagenerator.data;
 
+import java.lang.Object;
+import java.util.Arrays;
+import java.util.HashMap;
+
 /**
  * <code> MysqlToAvroMapper </code> maps Mysql data type to Avro data types.
  * @author chandan.bansal
@@ -94,16 +98,29 @@ public enum MysqlToAvroMapper
 	TIME("long"),
 
 	/** The year. */
-	YEAR("long");
+	YEAR("long"),
 
-	/** The avro type. */
-	private final String avroType;
+	/** For HashMap.
+	 * Though this Mysql Datatype does not exist, this required for
+	 * passing record changes in form of Avro Map datatype. Avro MAP datatype
+	 */
+	MAP(new HashMap<String, Object>(){{
+	        put("type", "map");
+			put("values", Arrays.asList("int", "long", "float", "double", "bytes", "string", "null"));
+	    }});
+
+
+	/** The avro type.
+	 * The reason its returning Object type because along with String datatypes required for defining "long","int" etc
+	 * We need to support Map (avro map datatype) which of the type HashMap
+	 */
+	private final Object avroType;
 
 	/**
 	 * enum constructor.
 	 * @param avroType the avro data type
 	 */
-	private MysqlToAvroMapper(String avroType)
+	private MysqlToAvroMapper(Object avroType)
 	{
 		this.avroType = avroType;
 	}
@@ -112,7 +129,7 @@ public enum MysqlToAvroMapper
 	 * Gets the avro type.
 	 * @return the avro type
 	 */
-	public String getAvroType()
+	public Object getAvroType()
 	{
 		return avroType;
 	}

--- a/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/data/TableRecord.java
+++ b/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/data/TableRecord.java
@@ -32,8 +32,20 @@ public class TableRecord
 		this.type = type;
 		this.doc = doc;
 		this.namespace = namespace;
-		this.meta = "pk=" + StringUtils.join(primaryKeys, ",");
+		this.meta = generateMeta(primaryKeys);
 		this.fields = fields;
+	}
+
+	public TableRecord(String name, String type, String doc, String namespace, List<String> primaryKeys,
+	        List<Field> fields, String rowChangeFieldName) throws IllegalArgumentException
+	{
+		this(name, type, doc, namespace, primaryKeys, fields);
+		if(rowChangeFieldName == null) { throw new IllegalArgumentException("rowChangeFieldName can't be NULL"); }
+		this.meta = generateMeta(primaryKeys) + "; rowChangeField=" + rowChangeFieldName;
+	}
+
+	private String generateMeta(List<String> primaryKeys) {
+	   return "pk=" + StringUtils.join(primaryKeys, ",");
 	}
 
 	/**
@@ -45,7 +57,7 @@ public class TableRecord
 		/** schema field name */
 		private String name;
 		/** array of field types */
-		private String[] type;
+		private Object[] type;
 		/** meta for the field */
 		private String meta;
 
@@ -53,7 +65,7 @@ public class TableRecord
 		{
 			/** this can be different from dbFieldName */
 			this.name = dbFieldName;
-			this.type = new String[]{MysqlToAvroMapper.valueOf(dbFieldType.toUpperCase()).getAvroType(), "null"};
+			this.type = new Object[]{MysqlToAvroMapper.valueOf(dbFieldType.toUpperCase()).getAvroType(), "null"};
 			this.meta =
 			        "dbFieldName=" + dbFieldName + ";dbFieldPosition=" + dbFieldPosition + ";dbFieldType="
 			                + dbFieldType;
@@ -69,7 +81,7 @@ public class TableRecord
 			this.name = name;
 		}
 
-		public String[] getType()
+		public Object[] getType()
 		{
 			return type;
 		}

--- a/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/main/InteractiveSchemaGenerator.java
+++ b/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/main/InteractiveSchemaGenerator.java
@@ -189,8 +189,7 @@ public class InteractiveSchemaGenerator
 	 * Run schema gen tool.
 	 * @return true, if successful
 	 */
-	public boolean runSchemaGenTool()
-	{
+	public boolean runSchemaGenTool() throws IllegalArgumentException {
 		for (String table : _tableNames)
 		{
 

--- a/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/main/SchemaGeneratorCli.java
+++ b/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/main/SchemaGeneratorCli.java
@@ -85,16 +85,16 @@ public class SchemaGeneratorCli
 
 			
 			String outputFolder=commandLine.getOptionValue("f");
+			String oldValueFieldName = commandLine.hasOption("q") ? commandLine.getOptionValue("q") : null;
+
 			//check if outputFolder exists, if not create one.
 			File f = new File(outputFolder);
 			if (!f.exists() || !f.isDirectory()) {
 					f.mkdir();
 				}
-			
-			
-			
+
 			SchemaGenerator schemaGenerator =
-			        new SchemaGenerator(dataSourceConfigs, tablesInclusionListMap, tablesExclusionListMap);
+			        new SchemaGenerator(dataSourceConfigs, tablesInclusionListMap, tablesExclusionListMap, oldValueFieldName);
 			System.out.println("Generating Schema ...\n");
 			if (commandLine.hasOption("t"))
 			{
@@ -150,16 +150,17 @@ public class SchemaGeneratorCli
 				.addOption("f", "output-folder", true, "path to the folder for storing output")
 				.addOption("v", "version", true, "version number of schema")
 				.addOption("h", "host", true, "host name for connection ; default localhost")
-		        .addOption("o", "port", true, "port for connection ; default 3306")
+				.addOption("o", "port", true, "port for connection ; default 3306")
 		        .addOption("u", "user", true, "user name for connection ; default root")
 		        .addOption("p", "password", true, "password for the connection ; default empty string")
 		        .addOption("t", "table", true, "table name for schema generation ; default all ")
 		        .addOption("e", "exclusion-list", true, "exclusion list ; default none")
 		        .addOption("i", "inclusion-list", true, "inclusion list ; default all")
-		        .addOption("?", "help", false, "help")
-		        .addOption(
-		                OptionBuilder.withArgName("dbName").withLongOpt("db").withDescription("db name for connection")
-		                        .hasArg().create('d'))
+				.addOption("?", "help", false, "help")
+				.addOption("q", "row-change-field", true, "fieldname to represents old-row-values")
+				.addOption(
+						OptionBuilder.withArgName("dbName").withLongOpt("db").withDescription("db name for connection")
+								.hasArg().create('d'))
 
 		        .addOption(
 		                OptionBuilder.withArgName("args").withLongOpt("exclusion-list")

--- a/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/mysql/MysqlUtils.java
+++ b/utilities/avro-schema-generator/src/main/java/com/flipkart/aesop/avro/schemagenerator/mysql/MysqlUtils.java
@@ -105,7 +105,7 @@ public class MysqlUtils
 
 	/**
 	 * Gets the primary keys.
-	 * @param dataSourceId the dataSourceId
+	 * @param dbName the dataSourceId
 	 * @param tableName the table name
 	 * @return the primary keys
 	 */
@@ -140,7 +140,6 @@ public class MysqlUtils
 
 	/**
 	 * Gets the fields in table.
-	 * @param dataSourceId the dataSourceId
 	 * @param db the database
 	 * @param table the table
 	 * @return the fields in table
@@ -174,7 +173,7 @@ public class MysqlUtils
 
 	/**
 	 * checks if the current table is a valid table in the given schema.
-	 * @param dataSourceId the dataSourceId
+	 * @param dataBase the dataSourceId
 	 * @param table : table name
 	 * @return true if valid table, false otherwise
 	 */
@@ -210,7 +209,6 @@ public class MysqlUtils
 
 	/**
 	 * Checks if the field is present in the table.
-	 * @param dataSourceId the dataSourceId
 	 * @param database the database
 	 * @param field The field to check if it's valid
 	 * @param table the table
@@ -247,7 +245,6 @@ public class MysqlUtils
 
 	/**
 	 * Gets the field details.
-	 * @param dataSourceId the dataSourceId
 	 * @param db the db name
 	 * @param table the table name
 	 * @return the field details
@@ -270,7 +267,6 @@ public class MysqlUtils
 				fieldInfoList.add(new TableRecord.Field(resultSet.getString("COLUMN_NAME"), resultSet
 				        .getString("DATA_TYPE"), resultSet.getInt("ORDINAL_POSITION")));
 			}
-
 		}
 		catch (SQLException e)
 		{


### PR DESCRIPTION
These changes are to enable old value propagation from mysql relay (producer). This is a flag based change, whereby in sample-mysql-relay this flag can be set. When enabled, in DBChangeEntry generic record which use to carry mysql-row field information (updated) will now have extra key: '_oldValue' (which will be a hash containing old values of changed field). The '_oldValue' column name depends on avro-schema defined. 
In schema-generator utility, a command line parameter is added which can be used if someone wants to generate schema with '_oldValue' column (column name is user defined in parameter). This will update meta properties in avro-schema, mentioning '_oldValue' is special column (not mysql column).
At clients side, in AbstractEvent a new field stores the information of '_oldValue' from DataBus event and can be used if required.

@jagadeesh-huliyar 
please have a look