### PR TITLE
Replaced "/" with File.separator

### DIFF
--- a/runtimes/runtime/src/main/java/com/flipkart/aesop/runtime/jetty/JettyWebAppContextFactory.java
+++ b/runtimes/runtime/src/main/java/com/flipkart/aesop/runtime/jetty/JettyWebAppContextFactory.java
@@ -72,8 +72,8 @@ public class JettyWebAppContextFactory implements FactoryBean<WebAppContext> {
 		for (File file : files) {
 			// we need only WEB-INF from the relevant project and none else even by mistake
 			String fileToString = file.toString();
-			if (fileToString.contains(".jar!") && fileToString.startsWith("file:/")) {
-				fileToString = fileToString.replace("file:/","jar:file:/");
+			if (fileToString.contains(".jar!") && fileToString.startsWith("file:"+File.separator)) {
+				fileToString = fileToString.replace("file:"+File.separator,"jar:file:"+File.separator);
 				if (fileToString.contains(moduleName + "-")) {
 					path = fileToString;
 					break;


### PR DESCRIPTION
Using "/" fails on non-nix OSs. Hence changed this to use File.separator instead.